### PR TITLE
Fix video playback and remove background

### DIFF
--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -24,9 +24,7 @@
   {% capture overlay_filter %}rgba(0, 0, 0, {{ page.header.overlay_filter }}){% endcapture %}
 {% endif %}
 
-<div class="page__hero{% if page.header.overlay_color or page.header.overlay_image %}--overlay{% endif %}"
-  style="{% if page.header.overlay_color %}background-color: {{ page.header.overlay_color | default: 'transparent' }};{% endif %} {% if overlay_img_path %}background-image: {% if overlay_filter %}linear-gradient({{ overlay_filter }}, {{ overlay_filter }}), {% endif %}url('{{ overlay_img_path }}');{% endif %}"
->
+<div class="page__hero">
   {% if page.header.overlay_color or page.header.overlay_image %}
     <div class="wrapper">
       <h1 class="page__title" itemprop="headline">

--- a/index.md
+++ b/index.md
@@ -12,17 +12,19 @@ I am a PhD Research Scholar at **Alliance School of Business, Alliance Universit
 <!-- ===== Featured Video Section ===== -->
 <section style="max-width:1100px; margin:1.5rem auto; padding:0 1rem;">
   <div style="position:relative; padding-top:56.25%; border-radius: 14px; overflow:hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.12);">
-    <iframe
-      src="https://g.co/gemini/share/a1e0506c13be"
-      title="Featured video"
-      style="position:absolute; top:0; left:0; width:100%; height:100%; border:0;"
-      allowfullscreen
-      loading="lazy"
-      referrerpolicy="no-referrer"
-    ></iframe>
+    <video
+      src="{{ '/sandeep-research-portfolio/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}"
+      style="position:absolute; top:0; left:0; width:100%; height:100%; border:0; object-fit:cover;"
+      playsinline
+      controls
+      preload="metadata"
+      poster="{{ '/images/video-poster.jpg' | relative_url }}"
+    >
+      Sorry, your browser doesn't support embedded videos. You can <a href="{{ '/sandeep-research-portfolio/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}">download the video</a> instead.
+    </video>
   </div>
   <div style="text-align:center; font-size:0.95rem; color:#4b5563; margin-top:.5rem;">
-    If the video doesn't load, <a href="https://g.co/gemini/share/a1e0506c13be" target="_blank" rel="noopener">open it in a new tab</a>.
+    If the video doesn't load, <a href="{{ '/sandeep-research-portfolio/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}" target="_blank" rel="noopener">open it in a new tab</a>.
   </div>
 </section>
 

--- a/index.md
+++ b/index.md
@@ -13,12 +13,14 @@ I am a PhD Research Scholar at **Alliance School of Business, Alliance Universit
 <section style="max-width:1100px; margin:1.5rem auto; padding:0 1rem;">
   <div style="position:relative; padding-top:56.25%; border-radius: 14px; overflow:hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.12);">
     <video
-      src="{{ '/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}"
       style="position:absolute; top:0; left:0; width:100%; height:100%; border:0; object-fit:cover;"
       playsinline
+      muted
+      autoplay
       controls
       preload="metadata"
     >
+      <source src="{{ '/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}" type="video/mp4" />
       Sorry, your browser doesn't support embedded videos. You can <a href="{{ '/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}">download the video</a> instead.
     </video>
   </div>

--- a/index.md
+++ b/index.md
@@ -13,18 +13,17 @@ I am a PhD Research Scholar at **Alliance School of Business, Alliance Universit
 <section style="max-width:1100px; margin:1.5rem auto; padding:0 1rem;">
   <div style="position:relative; padding-top:56.25%; border-radius: 14px; overflow:hidden; box-shadow: 0 10px 25px rgba(0,0,0,0.12);">
     <video
-      src="{{ '/sandeep-research-portfolio/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}"
+      src="{{ '/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}"
       style="position:absolute; top:0; left:0; width:100%; height:100%; border:0; object-fit:cover;"
       playsinline
       controls
       preload="metadata"
-      poster="{{ '/images/video-poster.jpg' | relative_url }}"
     >
-      Sorry, your browser doesn't support embedded videos. You can <a href="{{ '/sandeep-research-portfolio/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}">download the video</a> instead.
+      Sorry, your browser doesn't support embedded videos. You can <a href="{{ '/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}">download the video</a> instead.
     </video>
   </div>
   <div style="text-align:center; font-size:0.95rem; color:#4b5563; margin-top:.5rem;">
-    If the video doesn't load, <a href="{{ '/sandeep-research-portfolio/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}" target="_blank" rel="noopener">open it in a new tab</a>.
+    If the video doesn't load, <a href="{{ '/Futuristic_Infrastructure_Investment_Vision.mp4' | relative_url }}" target="_blank" rel="noopener">open it in a new tab</a>.
   </div>
 </section>
 

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: default
 title: "Sandeep S"
 subtitle: "PhD Research Scholar · Real Estate Investment Trusts & Infrastructure Investment Trusts"
 share: false


### PR DESCRIPTION
Remove the previously inserted background image and fix video playback by replacing the non-embeddable Gemini iframe with a native HTML5 video element.

---
<a href="https://cursor.com/background-agent?bcId=bc-823f6f25-26fa-46cd-9d6c-35d12216c835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-823f6f25-26fa-46cd-9d6c-35d12216c835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

